### PR TITLE
fix: 共有リンクはXのみ対応(一旦)

### DIFF
--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -59,6 +59,6 @@
 
   <!-- 戻るボタン -->
   <div class="mt-6">
-    <%= link_to "← 戻る", (!request.referer.index('tasks').nil? || !request.referer.index('mypage').nil?) ? (request.referer || root_path) : root_path, class: "btn btn-outline w-full" %>
+    <%= link_to "← 戻る", request.referer.index('t.co').nil? ? (request.referer || root_path) : root_path, class: "btn btn-outline w-full" %>
   </div>
 </div>


### PR DESCRIPTION
# 実装概要

タスク詳細ページの戻るボタンの遷移先を生成する処理を修正。
マイページ、タスク一覧、Xのシェアからのみを想定したものに修正

## 追加実装

issueに書いていないが追加した実装があればここに理由も合わせて書く

## 補足・備考

なにかあれば

## 質問・確認

聞きたいことや確認したいことがあれば
